### PR TITLE
[codex] Support directory symlink rules

### DIFF
--- a/.symlinks
+++ b/.symlinks
@@ -13,12 +13,15 @@
 .config/zed/settings.json
 
 # Coding Agent
-.agents/**
+.agents/AGENTS.md
+dir:.agents/skills/*
 !.agents/AGENTS.project.example.md
 
 # Claude Code
 .claude/**
 !.claude/README.md
+!.claude/skills/**
+dir:.claude/skills/*
 
 # OpenAI Codex
 .codex/config.toml
@@ -27,7 +30,7 @@
 .codex/rules/*.rules
 .codex/AGENTS.md
 .codex/prompts/*.md
-.codex/skills/**
+dir:.codex/skills/*
 !.codex/config.example.toml
 
 # Fish shell
@@ -51,6 +54,7 @@
 # Git configuration
 .gitconfig
 .gitconfig.*
+!.gitconfig.user
 .gitignore.global
 .gitattributes.global
 .git-hooks/*

--- a/scripts/symlink.py
+++ b/scripts/symlink.py
@@ -2,7 +2,7 @@
 """
 Symlink management script for dotfiles.
 
-Usage: symlink.py [--dry-run]
+Usage: symlink.py [--dry-run] [--replace-real-paths]
 """
 
 from __future__ import annotations
@@ -10,6 +10,8 @@ from __future__ import annotations
 import argparse
 import os
 import sys
+from dataclasses import dataclass
+from enum import Enum
 from pathlib import Path
 
 SCRIPT_DIR = Path(__file__).resolve().parent
@@ -34,89 +36,236 @@ def err(msg: str) -> None:
     sys.exit(1)
 
 
-def expand_pattern(base_dir: Path, pattern: str) -> list[Path]:
+class LinkKind(Enum):
+    """Type of link to create."""
+
+    FILE = "file"
+    DIRECTORY = "directory"
+
+
+@dataclass(frozen=True)
+class LinkPlan:
+    """A planned symlink operation."""
+
+    source: Path
+    target: Path
+    kind: LinkKind
+
+
+@dataclass(frozen=True)
+class SymlinkRule:
+    """One parsed rule from .symlinks."""
+
+    pattern: str
+    kind: LinkKind
+    include: bool
+
+
+def parse_rule(line: str) -> SymlinkRule | None:
+    """Parse a .symlinks line."""
+    line = line.strip()
+    if not line or line.startswith("#"):
+        return None
+
+    include = not line.startswith("!")
+    if not include:
+        line = line[1:]
+
+    kind = LinkKind.FILE
+    if line.startswith("dir:"):
+        kind = LinkKind.DIRECTORY
+        line = line.removeprefix("dir:")
+
+    return SymlinkRule(pattern=line, kind=kind, include=include)
+
+
+def expand_pattern(base_dir: Path, pattern: str, kind: LinkKind) -> list[Path]:
     """
-    Expand a glob pattern to matching files.
+    Expand a glob pattern to matching paths.
 
     Args:
         base_dir: Directory to search in.
         pattern: Glob pattern to expand.
+        kind: Type of paths to match.
 
     Returns:
-        List of matching file paths (relative to base_dir).
+        List of matching paths (relative to base_dir).
     """
     matches = []
     for path in base_dir.glob(pattern):
-        if path.is_file() or (path.is_symlink() and path.is_dir()):
+        if kind == LinkKind.FILE and path.is_file():
+            matches.append(path.relative_to(base_dir))
+        elif kind == LinkKind.DIRECTORY and path.is_dir():
             matches.append(path.relative_to(base_dir))
     return matches
 
 
-def get_matching_files(config_file: Path, base_dir: Path) -> list[Path]:
+def get_link_plans(
+    config_file: Path,
+    base_dir: Path,
+    target_dir: Path,
+) -> list[LinkPlan]:
     """
-    Get files matching patterns from config.
+    Get symlink plans matching patterns from config.
 
-    Processes include patterns and ! exclude patterns.
+    Processes file include/exclude patterns and dir: include/exclude patterns.
 
     Args:
         config_file: Path to .symlinks config.
         base_dir: Base directory for pattern matching.
+        target_dir: Base directory for symlink targets.
 
     Returns:
-        Sorted list of matching file paths.
+        Sorted list of link plans.
     """
-    included_files: set[Path] = set()
+    included: set[tuple[Path, LinkKind]] = set()
 
     with config_file.open() as f:
         for line in f:
-            line = line.strip()
-            if not line or line.startswith("#"):
+            rule = parse_rule(line)
+            if rule is None:
                 continue
 
-            if line.startswith("!"):
-                pattern = line[1:]
-                for match in expand_pattern(base_dir, pattern):
-                    included_files.discard(match)
-            else:
-                for match in expand_pattern(base_dir, line):
-                    included_files.add(match)
+            for match in expand_pattern(base_dir, rule.pattern, rule.kind):
+                key = (match, rule.kind)
+                if rule.include:
+                    included.add(key)
+                else:
+                    included.discard(key)
 
-    return sorted(included_files)
+    plans = [
+        LinkPlan(
+            source=base_dir / relative_path,
+            target=target_dir / relative_path,
+            kind=kind,
+        )
+        for relative_path, kind in included
+    ]
+    return sorted(plans, key=lambda plan: str(plan.target))
 
 
-def create_symlink(source: Path, target: Path, dry_run: bool) -> None:
+def link_points_to(target: Path, source: Path) -> bool:
+    """Return True if target is a symlink to source."""
+    if not target.is_symlink():
+        return False
+
+    link_target = target.readlink()
+    if link_target == source:
+        return True
+
+    if not link_target.is_absolute():
+        link_target = target.parent / link_target
+
+    return link_target.resolve(strict=False) == source.resolve(strict=False)
+
+
+def describe_plan(plan: LinkPlan) -> str:
+    """Return a compact display string for a plan."""
+    return f"{plan.kind.value}: {plan.target} -> {plan.source}"
+
+
+def is_unsafe_real_path(target: Path) -> bool:
+    """Return True when target is a non-symlink path that already exists."""
+    return (target.exists() or target.is_symlink()) and not target.is_symlink()
+
+
+def validate_link_plans(plans: list[LinkPlan], replace_real_paths: bool) -> None:
+    """Validate plans before applying any filesystem changes."""
+    seen_targets: dict[Path, LinkPlan] = {}
+    errors = []
+
+    for plan in plans:
+        existing = seen_targets.get(plan.target)
+        if existing is not None:
+            errors.append(
+                "Duplicate target planned: "
+                f"{plan.target} ({existing.kind.value}, {plan.kind.value})"
+            )
+        seen_targets[plan.target] = plan
+
+        if is_unsafe_real_path(plan.target) and not replace_real_paths:
+            errors.append(
+                f"Refusing to replace real path: {plan.target}\n"
+                "        Move it manually or re-run with --replace-real-paths."
+            )
+
+    if errors:
+        err("\n".join(errors))
+
+
+def remove_existing_path(path: Path) -> None:
+    """Remove an existing path that will be replaced by a symlink."""
+    if path.is_dir() and not path.is_symlink():
+        import shutil
+
+        shutil.rmtree(path)
+    else:
+        path.unlink()
+
+
+def create_symlink(
+    plan: LinkPlan,
+    dry_run: bool,
+    replace_real_paths: bool,
+) -> None:
     """
-    Create a symlink for a single file.
+    Create a symlink for a single plan.
 
     Skips if correct symlink exists. In dry-run mode, only logs what would be done.
-
-    Args:
-        source: Source file path (in dotfiles).
-        target: Target path (in $HOME).
-        dry_run: If True, only log actions without executing.
     """
-    if target.is_symlink() and target.readlink() == source:
-        log(f"Already linked: {target}")
+    source = plan.source
+    target = plan.target
+
+    if link_points_to(target, source):
+        log(f"Already linked: {describe_plan(plan)}")
         return
 
+    target_exists = target.exists() or target.is_symlink()
+    unsafe_real_path = is_unsafe_real_path(target)
+
     if dry_run:
-        if target.exists() or target.is_symlink():
-            log(f"[DRY-RUN] Would remove: {target}")
-        log(f"[DRY-RUN] Would create: {target} -> {source}")
+        if unsafe_real_path and not replace_real_paths:
+            warn(
+                f"[DRY-RUN] Would refuse to replace real path: "
+                f"{target} ({plan.kind.value})"
+            )
+            return
+        if target_exists:
+            log(f"[DRY-RUN] Would replace: {target}")
+        log(f"[DRY-RUN] Would create {describe_plan(plan)}")
         return
 
     target.parent.mkdir(parents=True, exist_ok=True)
 
-    if target.exists() or target.is_symlink():
-        if target.is_dir() and not target.is_symlink():
-            import shutil
-
-            shutil.rmtree(target)
-        else:
-            target.unlink()
+    if target_exists:
+        remove_existing_path(target)
 
     os.symlink(source, target)
-    log(f"Created: {target} -> {source}")
+    log(f"Created {describe_plan(plan)}")
+
+
+def get_matching_files(config_file: Path, base_dir: Path) -> list[Path]:
+    """
+    Get file matches from config.
+
+    Kept for compatibility with callers that only need file paths.
+    """
+    files: set[Path] = set()
+
+    with config_file.open() as f:
+        for line in f:
+            rule = parse_rule(line)
+            if rule is None or rule.kind != LinkKind.FILE:
+                continue
+
+            if rule.include:
+                for match in expand_pattern(base_dir, rule.pattern, rule.kind):
+                    files.add(match)
+            else:
+                for match in expand_pattern(base_dir, rule.pattern, rule.kind):
+                    files.discard(match)
+
+    return sorted(files)
 
 
 def parse_args() -> argparse.Namespace:
@@ -128,6 +277,11 @@ def parse_args() -> argparse.Namespace:
         "--dry-run",
         action="store_true",
         help="Show what would be done without making changes",
+    )
+    parser.add_argument(
+        "--replace-real-paths",
+        action="store_true",
+        help="Replace existing real files/directories that conflict with links",
     )
     return parser.parse_args()
 
@@ -145,18 +299,19 @@ def main() -> None:
     if args.dry_run:
         log("Dry-run mode enabled")
 
-    files = get_matching_files(CONFIG_FILE, DOTFILES_DIR)
+    plans = get_link_plans(CONFIG_FILE, DOTFILES_DIR, TARGET_DIR)
 
-    if not files:
+    if not plans:
         warn(f"No files matched patterns in {CONFIG_FILE}")
         return
 
-    log(f"Found {len(files)} files to symlink")
+    log(f"Found {len(plans)} links to symlink")
 
-    for file in files:
-        source = DOTFILES_DIR / file
-        target = TARGET_DIR / file
-        create_symlink(source, target, args.dry_run)
+    if not args.dry_run:
+        validate_link_plans(plans, args.replace_real_paths)
+
+    for plan in plans:
+        create_symlink(plan, args.dry_run, args.replace_real_paths)
 
     log("Done")
 

--- a/scripts/test_symlink.py
+++ b/scripts/test_symlink.py
@@ -1,0 +1,187 @@
+from contextlib import redirect_stderr, redirect_stdout
+import io
+from pathlib import Path
+import sys
+from tempfile import TemporaryDirectory
+from unittest import TestCase, main
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from symlink import (
+    LinkKind,
+    LinkPlan,
+    create_symlink,
+    get_link_plans,
+    validate_link_plans,
+)
+
+
+def write(path: Path, content: str = "") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+
+
+def quiet_call(func, *args, **kwargs):
+    """Run a logging helper without polluting test output."""
+    with redirect_stdout(io.StringIO()), redirect_stderr(io.StringIO()):
+        return func(*args, **kwargs)
+
+
+class SymlinkTest(TestCase):
+    def test_file_pattern_links_only_files(self) -> None:
+        with TemporaryDirectory() as tmp:
+            base = Path(tmp) / "repo"
+            target = Path(tmp) / "home"
+            write(base / ".config/tool/config.toml")
+            (base / ".config/tool/cache").mkdir(parents=True)
+            config = base / ".symlinks"
+            write(config, ".config/tool/**\n")
+
+            plans = get_link_plans(config, base, target)
+
+            self.assertEqual(
+                [plan.target.relative_to(target) for plan in plans],
+                [Path(".config/tool/config.toml")],
+            )
+            self.assertEqual(plans[0].kind, LinkKind.FILE)
+
+    def test_dir_pattern_links_directories_themselves(self) -> None:
+        with TemporaryDirectory() as tmp:
+            base = Path(tmp) / "repo"
+            target = Path(tmp) / "home"
+            write(base / ".agents/skills/commit/SKILL.md")
+            config = base / ".symlinks"
+            write(config, "dir:.agents/skills/*\n")
+
+            plans = get_link_plans(config, base, target)
+
+            self.assertEqual(
+                [plan.target.relative_to(target) for plan in plans],
+                [Path(".agents/skills/commit")],
+            )
+            self.assertEqual(plans[0].kind, LinkKind.DIRECTORY)
+
+    def test_dir_pattern_links_directory_symlinks_themselves(self) -> None:
+        with TemporaryDirectory() as tmp:
+            base = Path(tmp) / "repo"
+            target = Path(tmp) / "home"
+            write(base / ".agents/skills/commit/SKILL.md")
+            (base / ".codex/skills").mkdir(parents=True)
+            (base / ".codex/skills/commit").symlink_to(
+                "../../.agents/skills/commit",
+                target_is_directory=True,
+            )
+            config = base / ".symlinks"
+            write(config, "dir:.codex/skills/*\n")
+
+            plans = get_link_plans(config, base, target)
+
+            self.assertEqual(
+                [plan.target.relative_to(target) for plan in plans],
+                [Path(".codex/skills/commit")],
+            )
+            self.assertTrue(plans[0].source.is_symlink())
+            self.assertEqual(plans[0].kind, LinkKind.DIRECTORY)
+
+    def test_exclude_rules_remove_matching_plans(self) -> None:
+        with TemporaryDirectory() as tmp:
+            base = Path(tmp) / "repo"
+            target = Path(tmp) / "home"
+            write(base / ".config/tool/config.toml")
+            write(base / ".config/tool/local.toml")
+            write(base / ".agents/skills/commit/SKILL.md")
+            write(base / ".agents/skills/local/SKILL.md")
+            config = base / ".symlinks"
+            write(
+                config,
+                "\n".join(
+                    [
+                        ".config/tool/*.toml",
+                        "!.config/tool/local.toml",
+                        "dir:.agents/skills/*",
+                        "!dir:.agents/skills/local",
+                    ]
+                ),
+            )
+
+            plans = get_link_plans(config, base, target)
+
+            self.assertEqual(
+                [plan.target.relative_to(target) for plan in plans],
+                [Path(".agents/skills/commit"), Path(".config/tool/config.toml")],
+            )
+
+    def test_existing_correct_symlink_is_skipped(self) -> None:
+        with TemporaryDirectory() as tmp:
+            source = Path(tmp) / "repo/config.toml"
+            target = Path(tmp) / "home/config.toml"
+            write(source)
+            target.parent.mkdir(parents=True)
+            target.symlink_to(source)
+            plan = LinkPlan(source=source, target=target, kind=LinkKind.FILE)
+
+            quiet_call(create_symlink, plan, dry_run=False, replace_real_paths=False)
+
+            self.assertTrue(target.is_symlink())
+            self.assertEqual(target.readlink(), source)
+
+    def test_existing_wrong_symlink_is_replaced(self) -> None:
+        with TemporaryDirectory() as tmp:
+            source = Path(tmp) / "repo/config.toml"
+            old_source = Path(tmp) / "old/config.toml"
+            target = Path(tmp) / "home/config.toml"
+            write(source)
+            write(old_source)
+            target.parent.mkdir(parents=True)
+            target.symlink_to(old_source)
+            plan = LinkPlan(source=source, target=target, kind=LinkKind.FILE)
+
+            quiet_call(create_symlink, plan, dry_run=False, replace_real_paths=False)
+
+            self.assertTrue(target.is_symlink())
+            self.assertEqual(target.readlink(), source)
+
+    def test_real_directory_is_refused_by_default(self) -> None:
+        with TemporaryDirectory() as tmp:
+            source = Path(tmp) / "repo/.agents/skills/commit"
+            target = Path(tmp) / "home/.agents/skills/commit"
+            source.mkdir(parents=True)
+            target.mkdir(parents=True)
+            plan = LinkPlan(source=source, target=target, kind=LinkKind.DIRECTORY)
+
+            with self.assertRaises(SystemExit):
+                quiet_call(validate_link_plans, [plan], replace_real_paths=False)
+
+            self.assertTrue(target.is_dir())
+            self.assertFalse(target.is_symlink())
+
+    def test_real_directory_is_replaced_with_flag(self) -> None:
+        with TemporaryDirectory() as tmp:
+            source = Path(tmp) / "repo/.agents/skills/commit"
+            target = Path(tmp) / "home/.agents/skills/commit"
+            source.mkdir(parents=True)
+            target.mkdir(parents=True)
+            plan = LinkPlan(source=source, target=target, kind=LinkKind.DIRECTORY)
+
+            validate_link_plans([plan], replace_real_paths=True)
+            quiet_call(create_symlink, plan, dry_run=False, replace_real_paths=True)
+
+            self.assertTrue(target.is_symlink())
+            self.assertEqual(target.readlink(), source)
+
+    def test_dry_run_does_not_change_filesystem(self) -> None:
+        with TemporaryDirectory() as tmp:
+            source = Path(tmp) / "repo/config.toml"
+            target = Path(tmp) / "home/config.toml"
+            write(source, "new")
+            write(target, "old")
+            plan = LinkPlan(source=source, target=target, kind=LinkKind.FILE)
+
+            quiet_call(create_symlink, plan, dry_run=True, replace_real_paths=True)
+
+            self.assertEqual(target.read_text(), "old")
+            self.assertFalse(target.is_symlink())
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Add explicit `dir:` rules for symlinking whole directories.
- Build symlink operations through typed link plans.
- Refuse replacing real files/directories by default, with `--replace-real-paths` for intentional migrations.
- Update `.symlinks` so agent skills are linked as directories and `.gitconfig.user` is excluded.
- Add focused unittest coverage for file rules, directory rules, conflicts, replacement, and dry-run behavior.

## Validation

- `python3 -m py_compile scripts/symlink.py scripts/test_symlink.py`
- `python3 -m unittest scripts/test_symlink.py`
- `python3 scripts/symlink.py --dry-run`
