### PR TITLE
feat(statusline): show session ID on a second line

### DIFF
--- a/.claude/statusline/README.md
+++ b/.claude/statusline/README.md
@@ -1,6 +1,6 @@
 # statusline
 
-Modular statusline script for Claude Code. Displays model name, context usage, git branch, session duration, thinking mode, and API rate limits.
+Modular statusline script for Claude Code. Displays model name, context usage, git branch, session duration, thinking mode, and API rate limits, with the session ID on a second line.
 
 ## File Structure
 
@@ -9,7 +9,7 @@ Modular statusline script for Claude Code. Displays model name, context usage, g
 | `colors.sh` | ANSI color definitions and helper functions |
 | `git.sh` | Git branch and dirty state detection |
 | `oauth.sh` | OAuth token resolution |
-| `context.sh` | JSON extraction, session time, and Line 1 assembly |
+| `context.sh` | JSON extraction, session time, and status line assembly (main line + session ID line) |
 | `usage.sh` | API usage fetch, caching, and rate limit display |
 
 ## License

--- a/.claude/statusline/context.sh
+++ b/.claude/statusline/context.sh
@@ -18,11 +18,14 @@ build_line1() {
     (.context_window.current_usage.cache_creation_input_tokens // 0 | tostring),
     (.context_window.current_usage.cache_read_input_tokens // 0 | tostring),
     (.cwd // ""),
-    (.session.start_time // "")
-  ] | join("\t")')
+    (.session.start_time // ""),
+    (.session_id // "")
+  ] | join("\u001f")')
 
-  local model_name size input_tokens cache_create cache_read cwd session_start
-  IFS=$'\t' read -r model_name size input_tokens cache_create cache_read cwd session_start <<< "${jq_out}"
+  # Use a non-whitespace separator (US, \037): tab is an IFS whitespace char,
+  # so consecutive tabs collapse and shift fields when one value is empty.
+  local model_name size input_tokens cache_create cache_read cwd session_start session_id
+  IFS=$'\037' read -r model_name size input_tokens cache_create cache_read cwd session_start session_id <<< "${jq_out}"
 
   (( size == 0 )) && size=200000
   local current=$(( input_tokens + cache_create + cache_read ))
@@ -95,5 +98,12 @@ build_line1() {
     line1+="${DIM}◑ thinking${RESET}"
   fi
 
-  printf "%b" "${line1}"
+  # Session ID on a second line, left-aligned under the model.
+  # Claude Code renders each newline as a separate statusline row.
+  local line2=""
+  if [[ -n "${session_id}" && "${session_id}" != "null" ]]; then
+    line2="\n${DIM}${session_id}${RESET}"
+  fi
+
+  printf "%b" "${line1}${line2}"
 }


### PR DESCRIPTION
## Summary

- Display the Claude Code session ID left-aligned on a second status line, below the model/context/git/thinking line.
- Add `.session_id` to the existing single `jq` extraction (no extra process per render).
- Switch the field separator from tab to US (``). Tab is an IFS whitespace character, so consecutive tabs collapse and shift fields when a value (e.g. session start time) is empty — the US separator avoids that.

## Test plan

- [x] `session_id` present → renders on a second line under the model
- [x] `session_id` empty → single line, no trailing empty row
- [x] Non-empty `session.start_time` + `session_id` → fields stay aligned (regression for the separator fix)
- [x] `shellcheck --shell=bash` shows no new findings on changed lines